### PR TITLE
ignore whole example/ directory so bower install doen't get it

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "**/.*",
     "node_modules",
     "bower_components",
-    "example/js/vendor",
+    "example",
     "test",
     "tests"
   ],


### PR DESCRIPTION
The way I'm using it, 'bower install' is downloading parts of the source repo that I don't want. I've made this change so that I won't get the example/ directory in my dev env.
