### PR TITLE
ignore releases/ directory so bower install doen't get it

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,7 @@
     "node_modules",
     "bower_components",
     "example/js/vendor",
+    "releases",
     "test",
     "tests"
   ],


### PR DESCRIPTION
The way I'm using it, 'bower install' is downloading parts of the source repo that I don't want. I've made this change so that I won't get the releases/ directory in my dev env.
