### PR TITLE
move bootstrap and angular-mocks to devDependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,9 +25,11 @@
     "tests"
   ],
   "dependencies": {
-    "bootstrap": "~3.2.0",
     "angular": "~1.3.0",
-    "angular-mocks": "~1.3.0",
     "angular-sanitize": "~1.3.0"
+  },
+  "devDependencies": {
+    "bootstrap": "~3.2.0",
+    "angular-mocks": "~1.3.0"
   }
 }


### PR DESCRIPTION
Bootstrap and angular-mocks are not required for the general function of ngVideo. Moving these dependencies to devDependencies prevents other projects from accidentally adding these components to their own distribution.